### PR TITLE
change composer install * to composer require

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ __Table of content__
 **composer**:
 
 ```bash
-composer install kaoken/markdown-it-php
+composer require kaoken/markdown-it-php
 ```
 
 


### PR DESCRIPTION
composer install kaoken/markdown-it-php throws error in composer so I changed it to composer require kaoken/markdown-it-php